### PR TITLE
Add clean_up() call if removing dcm2bids attempt

### DIFF
--- a/oceanproc/bids_wrapper.py
+++ b/oceanproc/bids_wrapper.py
@@ -114,6 +114,7 @@ def run_dcm2bids(source_dir:Path,
                                           """))
         if ans:
             shutil.rmtree(path_that_exists)
+            clean_up()
         else:
             return
         


### PR DESCRIPTION
This will get rid of the data that's associated with a subject in `rawdata/tmp_dcm2bids/{some-subject}` (if there's any that exists) when prompted to restart dcm2bids at the start of oceanproc